### PR TITLE
Fixing issue #9 AttributeError: module 'numpy' has no attribute 'int'

### DIFF
--- a/python/pumapy/physics_models/finite_volume/anisotropic_conductivity_utils.c
+++ b/python/pumapy/physics_models/finite_volume/anisotropic_conductivity_utils.c
@@ -1299,7 +1299,7 @@ typedef npy_longdouble __pyx_t_5numpy_longdouble_t;
 
 /* "pumapy/physics_models/finite_volume/anisotropic_conductivity_utils.pyx":6
  * np.import_array()
- * DTYPE = np.int
+ * DTYPE = np.int_
  * ctypedef np.int_t DTYPE_t             # <<<<<<<<<<<<<<
  * 
  * 
@@ -23309,7 +23309,7 @@ if (!__Pyx_RefNanny) {
  * cimport numpy as np
  * 
  * np.import_array()             # <<<<<<<<<<<<<<
- * DTYPE = np.int
+ * DTYPE = np.int_
  * ctypedef np.int_t DTYPE_t
  */
   __pyx_t_2 = __pyx_f_5numpy_import_array(); if (unlikely(__pyx_t_2 == ((int)-1))) __PYX_ERR(0, 4, __pyx_L1_error)
@@ -23317,7 +23317,7 @@ if (!__Pyx_RefNanny) {
   /* "pumapy/physics_models/finite_volume/anisotropic_conductivity_utils.pyx":5
  * 
  * np.import_array()
- * DTYPE = np.int             # <<<<<<<<<<<<<<
+ * DTYPE = np.int_             # <<<<<<<<<<<<<<
  * ctypedef np.int_t DTYPE_t
  * 
  */

--- a/python/pumapy/physics_models/finite_volume/anisotropic_conductivity_utils.pyx
+++ b/python/pumapy/physics_models/finite_volume/anisotropic_conductivity_utils.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as np
 
 np.import_array()
-DTYPE = np.int
+DTYPE = np.int_
 ctypedef np.int_t DTYPE_t
 
 

--- a/python/pumapy/physics_models/finite_volume/elasticity_utils.c
+++ b/python/pumapy/physics_models/finite_volume/elasticity_utils.c
@@ -1299,7 +1299,7 @@ typedef npy_longdouble __pyx_t_5numpy_longdouble_t;
 
 /* "pumapy/physics_models/finite_volume/elasticity_utils.pyx":6
  * np.import_array()
- * DTYPE = np.int
+ * DTYPE = np.int_
  * ctypedef np.int_t DTYPE_t             # <<<<<<<<<<<<<<
  * 
  * 
@@ -30275,7 +30275,7 @@ if (!__Pyx_RefNanny) {
  * cimport numpy as np
  * 
  * np.import_array()             # <<<<<<<<<<<<<<
- * DTYPE = np.int
+ * DTYPE = np.int_
  * ctypedef np.int_t DTYPE_t
  */
   __pyx_t_2 = __pyx_f_5numpy_import_array(); if (unlikely(__pyx_t_2 == ((int)-1))) __PYX_ERR(0, 4, __pyx_L1_error)
@@ -30283,7 +30283,7 @@ if (!__Pyx_RefNanny) {
   /* "pumapy/physics_models/finite_volume/elasticity_utils.pyx":5
  * 
  * np.import_array()
- * DTYPE = np.int             # <<<<<<<<<<<<<<
+ * DTYPE = np.int_             # <<<<<<<<<<<<<<
  * ctypedef np.int_t DTYPE_t
  * 
  */

--- a/python/pumapy/physics_models/finite_volume/elasticity_utils.pyx
+++ b/python/pumapy/physics_models/finite_volume/elasticity_utils.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as np
 
 np.import_array()
-DTYPE = np.int
+DTYPE = np.int_
 ctypedef np.int_t DTYPE_t
 
 

--- a/python/pumapy/physics_models/finite_volume/isotropic_conductivity_utils.c
+++ b/python/pumapy/physics_models/finite_volume/isotropic_conductivity_utils.c
@@ -26253,7 +26253,7 @@ if (!__Pyx_RefNanny) {
  * import numpy as np
  * import sys             # <<<<<<<<<<<<<<
  * 
- * DTYPE = np.float
+ * DTYPE = np.float64
  */
   __pyx_t_1 = __Pyx_Import(__pyx_n_s_sys, 0, -1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 2, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -26263,7 +26263,7 @@ if (!__Pyx_RefNanny) {
   /* "pumapy/physics_models/finite_volume/isotropic_conductivity_utils.pyx":4
  * import sys
  * 
- * DTYPE = np.float             # <<<<<<<<<<<<<<
+ * DTYPE = np.float64             # <<<<<<<<<<<<<<
  * 
  * 
  */

--- a/python/pumapy/physics_models/finite_volume/isotropic_conductivity_utils.pyx
+++ b/python/pumapy/physics_models/finite_volume/isotropic_conductivity_utils.pyx
@@ -1,7 +1,7 @@
 import numpy as np
 import sys
 
-DTYPE = np.float
+DTYPE = np.float64
 
 
 def index_at_p(int i, int j, int k, int len_x, int len_y, int len_z):


### PR DESCRIPTION
np.float and np.int are a deprecated alias, causing them to issue a deprecation warning in numpy 1.20 and an error in numpy 1.24  when they are used.
To fix this we must use np.int_(default), np.int32 or np.int64 instead of np.int. And np.float64, np.float_, np.double (equivalent) instead of np.float. For detailed guidelines on how to deal with various deprecated types, have a closer look at the table and guideline in the [release notes for 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations):
_...
For float and complex you can use float64 and complex128 if you wish to be more explicit about the precision.

For np.int a direct replacement with np.int_ or int is also good and will not change behavior, but the precision will continue to depend on the computer and operating system. If you want to be more explicit and review the current use, you have the following alternatives:

np.int64 or np.int32 to specify the precision exactly. This ensures that results cannot depend on the computer or operating system.
np.int_ or int (the default), but be aware that it depends on the computer and operating system.
The C types: np.cint (int), np.int_ (long), np.longlong.
np.intp which is 32bit on 32bit machines 64bit on 64bit machines. This can be the best type to use for indexing.
..._

I have remplaced np.int to np.int_ and np.float to np.float64.
